### PR TITLE
sample wait queue with wait_event_interruptible

### DIFF
--- a/wait_queue/Makefile
+++ b/wait_queue/Makefile
@@ -1,0 +1,11 @@
+obj-m += wait_queue.o
+
+CONFIG_MODULE_SIG=n
+
+KDIR = /lib/modules/$(shell uname -r)/build
+ 
+all:
+	make -C $(KDIR)  M=$(shell pwd) modules
+ 
+clean:
+	make -C $(KDIR)  M=$(shell pwd) clean

--- a/wait_queue/wait_queue.c
+++ b/wait_queue/wait_queue.c
@@ -1,0 +1,187 @@
+/****************************************************************************//**
+*  \file       driver.c
+*
+*  \details    Simple linux driver (Waitqueue Dynamic method)
+*
+*  \author     EmbeTronicX
+*
+*  \Tested with Linux raspberrypi 5.10.27-v7l-embetronicx-custom+
+*
+*******************************************************************************/
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/kdev_t.h>
+#include <linux/fs.h>
+#include <linux/cdev.h>
+#include <linux/device.h>
+#include <linux/slab.h>                 //kmalloc()
+#include <linux/uaccess.h>              //copy_to/from_user()
+#include <linux/kthread.h>
+#include <linux/wait.h>                 // Required for the wait queues
+ 
+ 
+uint32_t read_count = 0;
+static struct task_struct *wait_thread;
+ 
+dev_t dev = 0;
+static struct class *dev_class;
+static struct cdev char_cdev;
+wait_queue_head_t my_wait_queue;
+int wait_queue_flag = 0;
+ 
+/*
+** Function Prototypes
+*/
+static int      __init my_driver_init(void);
+static void     __exit my_driver_exit(void);
+ 
+/*************** Driver functions **********************/
+static int      my_open(struct inode *inode, struct file *file);
+static int      my_release(struct inode *inode, struct file *file);
+static ssize_t  my_read(struct file *filp, char __user *buf, size_t len,loff_t * off);
+static ssize_t  my_write(struct file *filp, const char *buf, size_t len, loff_t * off);
+
+/*
+** File operation sturcture
+*/
+static struct file_operations fops =
+{
+        .owner          = THIS_MODULE,
+        .read           = my_read,
+        .write          = my_write,
+        .open           = my_open,
+        .release        = my_release,
+};
+ 
+/*
+** Thread function
+*/
+static int wait_function(void *unused)
+{
+        
+        while(1) {
+                pr_info("Waiting For Event...\n");
+                wait_event_interruptible(my_wait_queue, wait_queue_flag != 0 );
+                if(wait_queue_flag == 2) {
+                        pr_info("Event Came From Exit Function\n");
+                        return 0;
+                }
+                pr_info("Event Came From Read Function - %d\n", ++read_count);
+                wait_queue_flag = 0;
+        }
+        return 0;
+}
+ 
+/*
+** This function will be called when we open the Device file
+*/ 
+static int my_open(struct inode *inode, struct file *file)
+{
+        pr_info("Device File Opened...!!!\n");
+        return 0;
+}
+
+/*
+** This function will be called when we close the Device file
+*/
+static int my_release(struct inode *inode, struct file *file)
+{
+        pr_info("Device File Closed...!!!\n");
+        return 0;
+}
+
+/*
+** This function will be called when we read the Device file
+*/
+static ssize_t my_read(struct file *filp, char __user *buf, size_t len, loff_t *off)
+{
+        pr_info("Read Function\n");
+        wait_queue_flag = 1;
+        wake_up_interruptible(&my_wait_queue);
+        return 0;
+}
+
+/*
+** This function will be called when we write the Device file
+*/
+static ssize_t my_write(struct file *filp, const char __user *buf, size_t len, loff_t *off)
+{
+        pr_info("Write function\n");
+        return len;
+}
+
+/*
+** Module Init function
+*/
+static int __init my_driver_init(void)
+{
+        /*Allocating Major number*/
+        if((alloc_chrdev_region(&dev, 0, 1, "etx_Dev")) <0){
+                pr_info("Cannot allocate major number\n");
+                return -1;
+        }
+        pr_info("Major = %d Minor = %d \n",MAJOR(dev), MINOR(dev));
+ 
+        /*Creating cdev structure*/
+        cdev_init(&char_cdev,&fops);
+ 
+        /*Adding character device to the system*/
+        if((cdev_add(&char_cdev,dev,1)) < 0){
+            pr_info("Cannot add the device to the system\n");
+            goto r_class;
+        }
+ 
+        /*Creating struct class*/
+        if((dev_class = class_create(THIS_MODULE,"my_class")) == NULL){
+            pr_info("Cannot create the struct class\n");
+            goto r_class;
+        }
+ 
+        /*Creating device*/
+        if((device_create(dev_class,NULL,dev,NULL,"my_device")) == NULL){
+            pr_info("Cannot create the Device 1\n");
+            goto r_device;
+        }
+        
+        //Initialize wait queue
+        init_waitqueue_head(&my_wait_queue);
+ 
+        //Create the kernel thread with name 'mythread'
+        wait_thread = kthread_create(wait_function, NULL, "WaitThread");
+        if (wait_thread) {
+                pr_info("Thread Created successfully\n");
+                wake_up_process(wait_thread);
+        } else
+                pr_info("Thread creation failed\n");
+ 
+        pr_info("Device Driver Insert...Done!!!\n");
+        return 0;
+ 
+r_device:
+        class_destroy(dev_class);
+r_class:
+        unregister_chrdev_region(dev,1);
+        return -1;
+}
+
+/*
+** Module exit function
+*/
+static void __exit my_driver_exit(void)
+{
+        wait_queue_flag = 2;
+        wake_up_interruptible(&my_wait_queue);
+        device_destroy(dev_class,dev);
+        class_destroy(dev_class);
+        cdev_del(&char_cdev);
+        unregister_chrdev_region(dev, 1);
+        pr_info("Device Driver Remove...Done!!!\n");
+}
+ 
+module_init(my_driver_init);
+module_exit(my_driver_exit);
+ 
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("Simple linux driver (Waitqueue Dynamic method)");
+MODULE_VERSION("1.0");


### PR DESCRIPTION
sample wait queue problem which uses interruptible APIs 
we have created one thread named wait_function() in while(1). this thread will always wait for the event. 
It will sleep until it gets a wake_up call. When it gets the wake_up call, it will check the condition. If the condition is 1 then the wakeup came from the read function. If it is 2, then the wakeup came from an exit function.

used APIs:
init_waitqueue_head()     ( for Initialize wait queue)
kthread_create                (for creating kernel level thread)
static struct task_struct *wait_thread;  ( for creating thread)
wait_queue_head_t my_wait_queue;   ( for creating wait queue)

wait_event_interruptible()                  ( waiting for event)
wake_up_interruptible ()                    (for waking up the task from the queue for a unique event)
